### PR TITLE
observatory-bias: warm-start FindOrbOrbitFitter from a reference_orbi…

### DIFF
--- a/src/adam_fo/find_orb_orbit_fitter.py
+++ b/src/adam_fo/find_orb_orbit_fitter.py
@@ -263,6 +263,9 @@ class FindOrbOrbitFitter(OrbitFitter):
         TT. We coerce the seed orbit to that frame/origin and append a ``,TDB``
         or ``,UTC`` modifier so Find_Orb converts the epoch internally.
         """
+        assert (
+            len(reference_orbit) == 1
+        ), f"Expected a single seed orbit, got {len(reference_orbit)}"
         coords = transform_coordinates(
             reference_orbit.coordinates[:1],
             representation_out=CartesianCoordinates,
@@ -271,12 +274,7 @@ class FindOrbOrbitFitter(OrbitFitter):
         )
         scale = coords.time.scale
         jd = float(coords.time.jd().to_numpy(zero_copy_only=False)[0])
-        x = float(coords.x[0].as_py())
-        y = float(coords.y[0].as_py())
-        z = float(coords.z[0].as_py())
-        vx = float(coords.vx[0].as_py())
-        vy = float(coords.vy[0].as_py())
-        vz = float(coords.vz[0].as_py())
+        x, y, z, vx, vy, vz = coords.values[0]
 
         if scale == "tdb":
             modifier = ",TDB"

--- a/src/adam_fo/find_orb_orbit_fitter.py
+++ b/src/adam_fo/find_orb_orbit_fitter.py
@@ -7,6 +7,9 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from mpc_obscodes import mpc_obscodes
 
+from adam_core.coordinates.cartesian import CartesianCoordinates
+from adam_core.coordinates.origin import OriginCodes
+from adam_core.coordinates.transform import transform_coordinates
 from adam_core.dynamics.propagation import propagate_2body
 from adam_core.observations.ades import (
     ADES_to_string,
@@ -23,6 +26,7 @@ from adam_core.orbit_determination.evaluate import (
     evaluate_orbits,
 )
 from adam_core.orbit_determination.orbit_fitter import OrbitFitter
+from adam_core.orbits import Orbits
 from adam_core.propagator.propagator import Propagator
 
 try:
@@ -250,10 +254,48 @@ class FindOrbOrbitFitter(OrbitFitter):
 
         return od_orbit_members
 
+    def _build_state_vec_arg(self, reference_orbit: Orbits) -> str:
+        """Format the first row of ``reference_orbit`` for Find_Orb's ``-v`` flag.
+
+        Find_Orb's ``extract_state_vect_from_text()`` (find_orb/elem_out.cpp:3024)
+        expects ``"<epoch>,<x> <y> <z> <vx> <vy> <vz>[,<modifier>...]"`` with
+        units AU and AU/day in heliocentric ecliptic J2000, default time scale
+        TT. We coerce the seed orbit to that frame/origin and append a ``,TDB``
+        or ``,UTC`` modifier so Find_Orb converts the epoch internally.
+        """
+        coords = transform_coordinates(
+            reference_orbit.coordinates[:1],
+            representation_out=CartesianCoordinates,
+            frame_out="ecliptic",
+            origin_out=OriginCodes.SUN,
+        )
+        scale = coords.time.scale
+        jd = float(coords.time.jd().to_numpy(zero_copy_only=False)[0])
+        x = float(coords.x[0].as_py())
+        y = float(coords.y[0].as_py())
+        z = float(coords.z[0].as_py())
+        vx = float(coords.vx[0].as_py())
+        vy = float(coords.vy[0].as_py())
+        vz = float(coords.vz[0].as_py())
+
+        if scale == "tdb":
+            modifier = ",TDB"
+        elif scale == "utc":
+            modifier = ",UTC"
+        else:
+            modifier = ""
+
+        return (
+            f"{jd:.10f},"
+            f"{x:.12g} {y:.12g} {z:.12g} {vx:.12g} {vy:.12g} {vz:.12g}"
+            f"{modifier}"
+        )
+
     def initial_fit(
         self,
         object_id: str | pa.LargeStringScalar,
         observations: OrbitDeterminationObservations,
+        reference_orbit: Optional[Orbits] = None,
     ) -> Tuple[FittedOrbits, FittedOrbitMembers]:
         """Fit an initial orbit for a single object via Find_Orb.
 
@@ -261,6 +303,11 @@ class FindOrbOrbitFitter(OrbitFitter):
         evaluating the converged orbit against the input observations and
         ``success`` set to True. Outliers in ``FittedOrbitMembers`` reflect the
         observations that Find_Orb rejected; residuals on members are not set.
+
+        When ``reference_orbit`` is supplied, Find_Orb is warm-started from that
+        cartesian state via the ``-v`` flag, bypassing its Gauss/Vaisala cold
+        start. Pass ``None`` (the default) to preserve the legacy cold-start
+        behavior.
         """
         if observations is None or len(observations) == 0:
             logger.error(f"No observation provided for object {object_id}")
@@ -270,10 +317,16 @@ class FindOrbOrbitFitter(OrbitFitter):
         )
         ades_string, _ = self._observations_to_ades(observations)
 
+        state_vec = None
+        if reference_orbit is not None and len(reference_orbit) > 0:
+            state_vec = self._build_state_vec_arg(reference_orbit)
+            logger.info(f"Warm-starting Find_Orb for {object_id} with -v {state_vec}")
+
         orbit, rejected, error = fo(
             ades_string,
             out_dir=self.fo_result_dir,
             clean_up=self.clean_up_fo_dir,
+            state_vec=state_vec,
         )
         if error is not None:
             logger.error(f"FindOrb failed for object {object_id} with error {error}")

--- a/src/adam_fo/run_fo.py
+++ b/src/adam_fo/run_fo.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pathlib
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -98,6 +99,7 @@ def fo(
     clean_up: bool = True,
     out_dir: Optional[str] = None,
     temp_dir: Optional[str] = None,
+    state_vec: Optional[str] = None,
 ) -> Tuple[Orbits, ADESObservations, Optional[str]]:
     """Run programmatic Find_Orb orbit determination
 
@@ -111,10 +113,18 @@ def fo(
         If provided, the temporary directory will be copied to this path after running Find_Orb.
         The bc405.dat and DE440t files will not be copied.
     temp_dir : Optional[str], optional
-        If provided, the temporary directory will be created at this location. 
-        If not provided, the default temporary directory in ~/.cache/adam_fo/ will be used. 
-        It may be useful to explicitly set the path in HPC use cases, where user directories 
+        If provided, the temporary directory will be created at this location.
+        If not provided, the default temporary directory in ~/.cache/adam_fo/ will be used.
+        It may be useful to explicitly set the path in HPC use cases, where user directories
         often have stricter disk usage quotas.
+    state_vec : Optional[str], optional
+        Pre-formatted seed for Find_Orb's ``-v`` flag. When supplied, Find_Orb
+        bypasses Gauss/Vaisala cold-start and begins least-squares from this
+        state vector. Format is the one parsed by
+        ``extract_state_vect_from_text()`` in find_orb's ``elem_out.cpp``:
+        ``"<epoch>,<x> <y> <z> <vx> <vy> <vz>[,<modifier>...]"`` — units AU
+        and AU/day, default frame heliocentric ecliptic J2000, default time
+        scale TT (append ``,TDB`` or ``,UTC`` to convert).
 
     Returns
     -------
@@ -149,6 +159,8 @@ def fo(
         f"-D {fo_tmp_dir}/environ.dat "
         f"-O {fo_tmp_dir}"
     )
+    if state_vec is not None:
+        fo_command += f" -v {shlex.quote(state_vec)}"
 
     logger.debug(f"fo command: {fo_command}")
 

--- a/tests/test_find_orb_orbit_fitter.py
+++ b/tests/test_find_orb_orbit_fitter.py
@@ -2,14 +2,18 @@ import pickle
 import tempfile
 
 import numpy as np
+import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 from adam_fo.build import main as build_fo
 from adam_fo.config import check_build_exists
 
 from adam_core.coordinates import CoordinateCovariances, SphericalCoordinates
+from adam_core.coordinates.cartesian import CartesianCoordinates
 from adam_core.coordinates.origin import Origin
+from adam_core.observations.ades import ADESObservations
 from adam_core.observers import Observers
+from adam_core.orbits import Orbits
 from adam_core.time import Timestamp
 from adam_core.orbit_determination.evaluate import OrbitDeterminationObservations, OrbitDeterminationPhotometry
 from adam_fo.find_orb_orbit_fitter import FindOrbOrbitFitter
@@ -164,3 +168,139 @@ def test_not_enough_data(real_data):
     fitted_orbit, fitted_members = fitter.initial_fit(object_id, observations)
     assert len(fitted_orbit) == 0
     assert len(fitted_members) == 0
+
+
+def _make_seed_orbit(jd_tdb: float, x: float, y: float, z: float,
+                     vx: float, vy: float, vz: float) -> Orbits:
+    """Build a single-row heliocentric ecliptic J2000 Orbits in TDB."""
+    mjd = jd_tdb - 2400000.5
+    days = int(np.floor(mjd))
+    nanos = int(round((mjd - days) * 86_400 * 1_000_000_000))
+    epoch = Timestamp.from_kwargs(days=[days], nanos=[nanos], scale="tdb")
+    return Orbits.from_kwargs(
+        orbit_id=["seed-1"],
+        object_id=["TEST"],
+        coordinates=CartesianCoordinates.from_kwargs(
+            x=[x], y=[y], z=[z], vx=[vx], vy=[vy], vz=[vz],
+            time=epoch,
+            frame="ecliptic",
+            origin=Origin.from_kwargs(code=["SUN"]),
+        ),
+    )
+
+
+def test_initial_fit_omits_state_vec_without_seed(real_data, monkeypatch):
+    """Backward compatibility: with reference_orbit unset, ``initial_fit`` must
+    invoke the underlying ``fo`` wrapper without a ``state_vec`` (cold-start
+    path preserved exactly as before bead 9sg).
+    """
+    captured = {}
+
+    def fake_fo(ades_string, out_dir=None, clean_up=True, state_vec=None,
+                **_):
+        captured["state_vec"] = state_vec
+        return Orbits.empty(), ADESObservations.empty(), "stop"
+
+    monkeypatch.setattr("adam_fo.find_orb_orbit_fitter.fo", fake_fo)
+
+    fitter = FindOrbOrbitFitter(fo_result_dir="/tmp/unused")
+    fitter.initial_fit("2009 JY22", real_data)
+
+    assert captured["state_vec"] is None
+
+
+def test_initial_fit_forwards_reference_orbit_as_state_vec(real_data, monkeypatch):
+    """When reference_orbit is supplied, the seed must reach Find_Orb's ``-v``
+    flag in the format ``"<jd>,<x> <y> <z> <vx> <vy> <vz>[,<scale>]"`` parsed
+    by ``extract_state_vect_from_text`` in ``find_orb/elem_out.cpp``. The seed
+    is converted to heliocentric ecliptic J2000 cartesian (Find_Orb's default
+    frame) and the time scale is appended so Find_Orb can convert internally.
+    """
+    captured = {}
+
+    def fake_fo(ades_string, out_dir=None, clean_up=True, state_vec=None,
+                **_):
+        captured["state_vec"] = state_vec
+        return Orbits.empty(), ADESObservations.empty(), "stop"
+
+    monkeypatch.setattr("adam_fo.find_orb_orbit_fitter.fo", fake_fo)
+
+    seed = _make_seed_orbit(
+        jd_tdb=2459580.5,
+        x=1.5, y=1.6, z=0.05,
+        vx=-0.011, vy=0.0095, vz=-0.0005,
+    )
+
+    fitter = FindOrbOrbitFitter(fo_result_dir="/tmp/unused")
+    fitter.initial_fit("2009 JY22", real_data, reference_orbit=seed)
+
+    sv = captured["state_vec"]
+    assert sv is not None, "state_vec must be passed when reference_orbit is supplied"
+    # Format: "<jd>,<x> <y> <z> <vx> <vy> <vz>,TDB"
+    epoch_part, state_part, scale_part = sv.split(",")
+    assert abs(float(epoch_part) - 2459580.5) < 1e-6
+    components = state_part.split()
+    assert len(components) == 6
+    nums = [float(c) for c in components]
+    np.testing.assert_allclose(
+        nums,
+        [1.5, 1.6, 0.05, -0.011, 0.0095, -0.0005],
+        rtol=1e-9,
+        atol=1e-12,
+    )
+    assert scale_part == "TDB"
+
+
+def test_warm_start_recovers_catastrophic_cold_start(real_data):
+    """Regression test for bead 9sg + 39j: when Find_Orb's Gauss/Vaisala IOD
+    is geometrically degenerate (a 4-observation, ~3-minute G96 tracklet from
+    the real_data fixture), cold-start ``initial_fit`` returns an empty
+    ``FittedOrbits`` — no covariance is produced and the worker has no orbit
+    to hand back. Supplying ``reference_orbit`` makes Find_Orb take the ``-v``
+    branch in ``fetch_previous_solution()`` (find_orb/elem_out.cpp:3244) and
+    skip the IOD altogether, converging via least-squares from the seed.
+
+    This mirrors the catastrophic-cold-start tail observed in pilot v11
+    (8.82% of LOOO rows above 60 arcsec, max 261k arcsec residual): without
+    a seed, short held-in arcs produce either no orbit or an orbit so far
+    from truth that downstream evaluation chi² explodes. With a seed, the
+    fitter converges. See adam_orbit_det_eval/docs/findorb-warm-start.md.
+    """
+    obs_full = real_data
+    short = obs_full[:4]  # 3-minute G96 tracklet — Gauss IOD is degenerate
+
+    out_full = tempfile.TemporaryDirectory()
+    seed_orbit, _ = FindOrbOrbitFitter(fo_result_dir=out_full.name).initial_fit(
+        "2009 JY22", obs_full
+    )
+    assert len(seed_orbit) == 1, "full fixture must converge cold to provide a seed"
+    seed = seed_orbit.to_orbits()
+
+    out_cold = tempfile.TemporaryDirectory()
+    cold_fitter = FindOrbOrbitFitter(fo_result_dir=out_cold.name)
+    cold_fit, _ = cold_fitter.initial_fit("2009 JY22", short)
+    assert len(cold_fit) == 0, (
+        "cold-start on the 3-minute tracklet must fail (degenerate Gauss IOD); "
+        "if this assertion fires the fixture has shifted and the warm-start "
+        "comparison below is no longer measuring the catastrophic-recovery path"
+    )
+
+    out_warm = tempfile.TemporaryDirectory()
+    warm_fitter = FindOrbOrbitFitter(fo_result_dir=out_warm.name)
+    warm_fit, _ = warm_fitter.initial_fit("2009 JY22", short, reference_orbit=seed)
+    assert len(warm_fit) == 1, "warm-start with seed must produce a fitted orbit"
+    assert warm_fit.success[0].as_py() is True
+    assert warm_fit.reduced_chi2[0].is_valid
+
+    # The warm-start orbit must be physically sensible: main-belt heliocentric
+    # distance, not a degenerate IOD result like r2 -> 0 or r2 -> infinity.
+    warm_xyz = np.array([
+        warm_fit.coordinates.x[0].as_py(),
+        warm_fit.coordinates.y[0].as_py(),
+        warm_fit.coordinates.z[0].as_py(),
+    ])
+    helio_dist = float(np.linalg.norm(warm_xyz))
+    assert 1.0 < helio_dist < 5.0, (
+        f"warm-start heliocentric distance {helio_dist:.3f} AU outside main-belt "
+        f"range — seed did not anchor the LSQ"
+    )


### PR DESCRIPTION
Add a `reference_orbit` parameter to `FindOrbOrbitFitter.initial_fit` and a `state_vec` parameter to the `fo` wrapper. When supplied, the seed is formatted for Find_Orb's `-v` flag (epoch + heliocentric ecliptic J2000 cartesian state, with the time scale appended so `extract_state_vect_from_text` in `find_orb/elem_out.cpp` can convert internally) and Find_Orb takes the warm-start branch in `fetch_previous_solution()`, skipping its Gauss/Vaisala cold start. Cold-start behavior is preserved exactly when `reference_orbit` is None.